### PR TITLE
Fix incorrect player positions in formation display

### DIFF
--- a/src/pages/PublicSession.tsx
+++ b/src/pages/PublicSession.tsx
@@ -529,8 +529,7 @@ const PublicSession = () => {
                         // Prova prima con roleShort, poi con role come fallback, infine con name
                         const roleToCheck = position.roleShort || (position as any).role || position.name || ''
                         const matchesRole = sector.roles.some(role => 
-                          roleToCheck.toLowerCase().includes(role.toLowerCase()) ||
-                          role.toLowerCase().includes(roleToCheck.toLowerCase())
+                          roleToCheck.toLowerCase() === role.toLowerCase()
                         )
                         return hasPlayer && matchesRole
                       }) || []


### PR DESCRIPTION
Fix player role assignment by using exact match instead of partial match.

The previous logic used `includes()` in both directions, causing roles like 'P' (goalkeeper) to match other roles (e.g., 'ATT' for attacker) if the role string contained the letter 'P'. This resulted in players appearing in incorrect sectors.

---
<a href="https://cursor.com/background-agent?bcId=bc-e1e15a91-5843-4657-96d5-852a35ad2af3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e1e15a91-5843-4657-96d5-852a35ad2af3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>