### PR TITLE
Fix duplicate setDefaultBackground definition

### DIFF
--- a/src/hooks/useAvatarBackgrounds.ts
+++ b/src/hooks/useAvatarBackgrounds.ts
@@ -155,7 +155,7 @@ export const useAvatarBackgrounds = () => {
     }
   }
 
-  const setDefaultBackground = async (id: string) => {
+  const setAsDefaultBackground = async (id: string) => {
     try {
       // Remove default from all backgrounds
       await supabase
@@ -222,7 +222,7 @@ export const useAvatarBackgrounds = () => {
     createBackground,
     updateBackground,
     deleteBackground,
-    setDefaultBackground,
+    setAsDefaultBackground,
     uploadImage
   }
 }


### PR DESCRIPTION
Rename `setDefaultBackground` function to `setAsDefaultBackground` to resolve a naming conflict.

The name `setDefaultBackground` was used for both a state setter and an async function, leading to a "defined multiple times" error.

---
<a href="https://cursor.com/background-agent?bcId=bc-05c929f4-6c2d-4baf-a630-e44fc89e1ceb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-05c929f4-6c2d-4baf-a630-e44fc89e1ceb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>